### PR TITLE
fixed bug in emplyer profile

### DIFF
--- a/lib/views/home/employer_profile.dart
+++ b/lib/views/home/employer_profile.dart
@@ -131,11 +131,18 @@ class _EmployerProfileState extends State<EmployerProfile> {
               children: [
                 CircleAvatar(
                   radius: 50,
-                  backgroundImage: kIsWeb ? MemoryImage(_webImage!) : showPFP(),
+                  backgroundImage: kIsWeb ? _webImage != null ? MemoryImage(_webImage!) : null : showPFP(),
                   child: _imageLink == null || _imageLink!.isEmpty
                       ? Icon(Icons.person, size: 50)
                       : null,
                 ),
+                if (_webImage == null)
+                  Positioned.fill(
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
                 Positioned(
                   bottom: 0,
                   right: 0,


### PR DESCRIPTION
- the _webImage is null for a split second when image is not loaded, that's why an error occurs